### PR TITLE
Revert "APID-413 - Remove outgoing size limit as we check on the submission o…"

### DIFF
--- a/app/uk/gov/hmrc/pushpullnotificationsgateway/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsgateway/config/AppConfig.scala
@@ -36,4 +36,6 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   val useProxy: Boolean = config.getOptional[Boolean]("proxy.proxyRequiredForThisEnvironment").getOrElse(false)
   val validateHttpsCallbackUrl: Boolean = config.getOptional[Boolean]("validateHttpsCallbackUrl").getOrElse(true)
   val authorizationToken: String = config.get[String]("authorizationKey")
+
+  val maxNotificationSize = config.underlying.getBytes("notifications.maxSize").intValue()
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsgateway/controllers/OutboundNotificationController.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsgateway/controllers/OutboundNotificationController.scala
@@ -49,7 +49,7 @@ class OutboundNotificationController @Inject()(appConfig: AppConfig,
     (Action andThen
       validateAuthorizationHeaderAction andThen
       validateUserAgentHeaderAction)
-      .async(playBodyParsers.json) { implicit request =>
+      .async(playBodyParsers.json(maxLength = appConfig.maxNotificationSize)) { implicit request =>
     withJsonBody[OutboundNotification] {
       notification => {
         if(validateNotification(notification)) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -134,4 +134,5 @@ microservice {
 
 whitelisted.useragents = ["push-pull-notifications-api"]
 allowedHostList = []
+notifications.maxSize = 100K
 authorizationKey = "aWFtcHVzaHB1bGxhcGk="


### PR DESCRIPTION
Reverts hmrc/push-pull-notifications-gateway#39

Turns out there is an internal limit to playBodyParsers.json of 100kb so reverting this and then going to bump the previous check to 200kb